### PR TITLE
docs: add CI/CD research for Week 1

### DIFF
--- a/docs/ci_research.md
+++ b/docs/ci_research.md
@@ -1,0 +1,52 @@
+# CI/CD Research - GitHub Actions
+
+This document summarizes the Continuous Integration (CI) approach planned for the project using GitHub Actions.
+
+## Purpose
+The CI pipeline will help:
+- Automatically build the C++ project
+- Detect build errors early
+- Improve code quality and collaboration
+
+## Tool: GitHub Actions
+GitHub Actions is chosen because:
+- It is integrated with GitHub repositories
+- Supports custom workflows using YAML
+- Has free minutes for public repositories
+
+## Planned Workflow
+The CI workflow will be triggered:
+- On every push to the `develop` branch
+- On every pull request targeting `develop`
+
+### Steps (Draft)
+1. Checkout repository
+2. Set up C++ build environment
+3. Install dependencies (CMake, compiler, libpqxx)
+4. Build the project
+5. (Future) Run unit and integration tests
+
+## Example Workflow File (Draft)
+
+```yaml
+name: C++ CI
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make


### PR DESCRIPTION
## What changed?
- Added CI/CD research document for Week 1 under docs/ci_research.md
- Document describes proposed GitHub Actions pipeline for build and tests

## Why?
- To fulfill Week 1 requirement for CI research and planning
- To prepare CI/CD integration for upcoming development weeks

## How to test?
- [x] Build passes
- [x] No code changes, documentation only

## Related issues
Closes # (if applicable)
